### PR TITLE
Fixed install on systems running systemd-resolved

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,3 +16,8 @@
   tags:
     - dnsmasq_config
   when: dnsmasq_config
+
+- include: systemd_resolved.yml
+  when: >
+        ansible_service_mgr == "systemd" and
+        dnsmasq_systemd_resolved_disable

--- a/tasks/systemd_resolved.yml
+++ b/tasks/systemd_resolved.yml
@@ -1,0 +1,44 @@
+---
+- name:         systemd_resolved | Checking If systemd-resolved Service Is Present
+  command:      systemctl status systemd-resolved.service
+  register:     _dnsmasq_systemd_resolved_check
+  changed_when: false
+  failed_when:  false
+
+- name:         systemd_resolved | Disabling and Stopping systemd-resolved
+  service:
+    name:       systemd-resolved
+    state:      stopped
+    enabled:    false
+  become:       true
+  register:     _dnsmasq_systemd_resolved_disabled
+  notify:
+    - restart dnsmasq
+  when:         _dnsmasq_systemd_resolved_check['rc'] == 0
+
+- name:         systemd_resolved | Checking If /etc/resolv.conf Exists
+  stat:
+    path:       /etc/resolv.conf
+  register:     _dnsmasq_resolv_conf
+
+- name:         systemd_resolved | Removing Existing /etc/resolv.conf If symlink
+  file:
+    path:       /etc/resolv.conf
+    state:      absent
+  become:       true
+  register:     _dnsmasq_resolv_conf_removed
+  when:         >
+        _dnsmasq_systemd_resolved_disabled['changed'] and
+        _dnsmasq_resolv_conf['stat']['islnk']
+
+- name:         systemd_resolved | Creating /etc/resolv.conf
+  template:
+    src:        etc/resolv.conf.j2
+    dest:       /etc/resolv.conf
+    owner:      root
+    group:      root
+    mode:       o=rw,g=r,o=r
+  become:       true
+  notify:
+    - restart dnsmasq
+  when:         _dnsmasq_resolv_conf_removed['changed']

--- a/templates/etc/resolv.conf.j2
+++ b/templates/etc/resolv.conf.j2
@@ -1,0 +1,3 @@
+{{ ansible_managed|comment }}
+search {{ dnsmasq_dns_search }}
+nameserver 127.0.0.1:{{ dnsmasq_listen_port }}


### PR DESCRIPTION
On newer distros that have systemd-resolved installed by default,
DNSMasq does not appear to be functional after installing. This resolves
that issue and ensures that DNSMasq is functional.