### PR TITLE
Fix bogus-priv option.

### DIFF
--- a/templates/etc/dnsmasq.conf.j2
+++ b/templates/etc/dnsmasq.conf.j2
@@ -21,7 +21,7 @@ bind-interfaces
 except-interface={{ item }}
 {%   endfor %}
 {% endif %}
-{% if dnsmasq_forward_nonrouted_addresses %}
+{% if not dnsmasq_forward_nonrouted_addresses %}
 bogus-priv
 {% endif %}
 {% if dnsmasq_pri_domain_name is defined %}


### PR DESCRIPTION
The [`bogus-priv`](https://github.com/imp/dnsmasq/blob/master/man/dnsmasq.8#L308) option tells dnsmasq **not** to forward nonrouted addresses for reverse DNS resolution. Therefore, setting [`dnsmasq_forward_nonrouted_addresses`](https://github.com/mrlesmithjr/ansible-dnsmasq/blob/master/defaults/main.yml#L90) to `true` should **suppress** this option, rather than setting it.