### PR TITLE
Fix /etc/resolv.conf not being configured

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,6 @@
   when: dnsmasq_config
 
 - include: systemd_resolved.yml
-  when: >
-    ansible_service_mgr == "systemd" and
-    dnsmasq_systemd_resolved_disable
+  when:
+    - ansible_service_mgr == "systemd"
+    - dnsmasq_systemd_resolved_disable

--- a/tasks/systemd_resolved.yml
+++ b/tasks/systemd_resolved.yml
@@ -27,9 +27,9 @@
     state: absent
   become: true
   register: _dnsmasq_resolv_conf_removed
-  when: >
-    _dnsmasq_systemd_resolved_disabled['changed'] and
-    _dnsmasq_resolv_conf['stat']['islnk']
+  when:
+    - _dnsmasq_systemd_resolved_disabled['changed']
+    - _dnsmasq_resolv_conf['stat']['islnk']
 
 - name: systemd_resolved | Creating /etc/resolv.conf
   template:
@@ -41,4 +41,4 @@
   become: true
   notify:
     - restart dnsmasq
-  when: _dnsmasq_resolv_conf_removed['changed']
+  when: ansible_virtualization_type != "docker"


### PR DESCRIPTION
/etc/resolv.conf needs be updated when systemd-resolved is in use. It
was only being updated when /etc/resolv.conf was a symlink.