### PR TITLE
Authorize empty value for dhcp-option to disabled it

### DIFF
--- a/templates/etc/dnsmasq.conf.j2
+++ b/templates/etc/dnsmasq.conf.j2
@@ -72,7 +72,8 @@ dhcp-host={{ item['mac_address']|join(',') }}{% if item['name'] is defined %},{{
 {%   endif %}
 {%   if dnsmasq_dhcp_options is defined and dnsmasq_dhcp_options != [] %}
 {%     for item in dnsmasq_dhcp_options %}
-dhcp-option=option:{{ item['option'] }},{{ item['value']|join(',') }}
+dhcp-option=option:{{ item['option'] }}{% if item['value'] is defined %},{{ item['value']|join(',') }}{% endif %}
+
 {%     endfor %}
 {%   endif %}
 {%   if dnsmasq_dhcp_scopes is defined and dnsmasq_dhcp_scopes != [] %}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Authorize empty value for dhcp-option to disabled it

## Description
By default dnsmasq with dhcp enabled send standard options to DHCP clients (DNS server, default route, …)
To disabled it, we need to setup dnsmasq.con with dhcp-options with empty value which is not possible currently ( single `,` is always added)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
