### PR TITLE
make nameserver value of /etc/resolv.conf configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,6 +104,10 @@ dnsmasq_forward_nonrouted_addresses: false
 # Set to 0 to disable DNS
 dnsmasq_listen_port: 53
 
+# value for nameserver in /etc/resolv.conf some tools do not like the :port argument 
+# may ovveride such as 127.0.0.1
+dnsmasq_resolvconf_nameserver: "127.0.0.1:{{ dnsmasq_listen_port }}"
+
 # Define your dns servers
 dnsmasq_nameservers:
   - 8.8.4.4

--- a/templates/etc/resolv.conf.j2
+++ b/templates/etc/resolv.conf.j2
@@ -1,3 +1,4 @@
 {{ ansible_managed|comment }}
 search {{ dnsmasq_dns_search }}
-nameserver 127.0.0.1:{{ dnsmasq_listen_port }}
+nameserver {{ dnsmasq_resolvconf_nameserver }}
+dnsmasq_resolvconf_nameserver: "127.0.0.1:{{ dnsmasq_listen_port }}"

--- a/templates/etc/resolv.conf.j2
+++ b/templates/etc/resolv.conf.j2
@@ -1,4 +1,3 @@
 {{ ansible_managed|comment }}
 search {{ dnsmasq_dns_search }}
 nameserver {{ dnsmasq_resolvconf_nameserver }}
-dnsmasq_resolvconf_nameserver: "127.0.0.1:{{ dnsmasq_listen_port }}"


### PR DESCRIPTION
add  backwards-compatible defaults value to override contents of /etc/resolv.conf nameserver for those needing a workaround.
## Description
programs like dig and nslookup parse /etc/resolv.conf directly and do not support the port attribute of `nameserver host:port`

this default var lets a user override to a value like `127.0.0.1` if the port isn't needed.



## Related Issue

[(https://github.com/mrlesmithjr/ansible-dnsmasq/issues/37)](https://github.com/mrlesmithjr/ansible-dnsmasq/issues/37)

as able to duplicate issue with latest debian

before
```
root@nanopi-r5s:/etc# dig google.com
dig: parse of /etc/resolv.conf failed
```
after
```
root@nanopi-r5s:/etc# dig google.com

; <<>> DiG 9.18.16-1-Debian <<>> google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 61085
;; flags: qr rd ra; QUERY: 1, ANSWER: 6, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;google.com.                    IN      A

;; ANSWER SECTION:
google.com.             112     IN      A       142.251.163.139
google.com.             112     IN      A       142.251.163.113
google.com.             112     IN      A       142.251.163.101
google.com.             112     IN      A       142.251.163.138
google.com.             112     IN      A       142.251.163.100
google.com.             112     IN      A       142.251.163.102

;; Query time: 9 msec
;; SERVER: 127.0.0.1#53(127.0.0.1) (UDP)
;; WHEN: Tue Sep 05 23:52:20 UTC 2023
;; MSG SIZE  rcvd: 135
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
